### PR TITLE
[Editorial] Use conventional spelling of poet's name in the epigraph

### DIFF
--- a/src/epub/text/epigraph.xhtml
+++ b/src/epub/text/epigraph.xhtml
@@ -18,7 +18,7 @@
 					<br/>
 					<span>witches, and ghosts who rove at midnight hour.</span>
 				</p>
-				<cite>Horat</cite>
+				<cite>Horace</cite>
 			</blockquote>
 		</section>
 	</body>


### PR DESCRIPTION
Since the epigraph uses a quotation from the ancient Roman poet Horace, it seems best to me to spell out his name following the conventional spelling, instead of using a less common or abbreviated form.

**Edit:** I just noticed that `Horat.` is used in the epigraph for the SE version of William Wycherley's _The Country Wife_. Other editions that I've seen of _The Monk_ use the abbreviation `Hor.`. So, alternatively, the current form could be kept, but marked as an abbreviation (for `Horatius`, the nominative form of the poet's nomen gentilicium).